### PR TITLE
SamSort async for BlockCompressedOutputStream

### DIFF
--- a/src/main/java/htsjdk/samtools/model/CompressedBlock.java
+++ b/src/main/java/htsjdk/samtools/model/CompressedBlock.java
@@ -1,0 +1,31 @@
+package htsjdk.samtools.model;
+
+public class CompressedBlock {
+
+    private int compressedSize;
+    private int bytesToCompress;
+    private byte[] compressedBuffer;
+
+    public CompressedBlock(int compressedSize, int bytesToCompress, byte[] compressedBuffer) {
+        this.compressedSize = compressedSize;
+        this.bytesToCompress = bytesToCompress;
+        this.compressedBuffer = compressedBuffer;
+    }
+
+    //For poison pill only
+    public CompressedBlock() {
+    }
+
+    public int getCompressedSize() {
+        return compressedSize;
+    }
+
+    public int getBytesToCompress() {
+        return bytesToCompress;
+    }
+
+    public byte[] getCompressedBuffer() {
+        return compressedBuffer;
+    }
+
+}

--- a/src/main/java/htsjdk/samtools/model/TempBlock.java
+++ b/src/main/java/htsjdk/samtools/model/TempBlock.java
@@ -1,0 +1,29 @@
+package htsjdk.samtools.model;
+
+public class TempBlock {
+    private int bytesToCompress;
+    private byte[] uncompressedBuffer;
+    private byte[] compressedBuffer;
+
+    public TempBlock(int bytesToCompress, byte[] uncompressedBuffer, byte[] compressedBuffer) {
+        this.bytesToCompress = bytesToCompress;
+        this.uncompressedBuffer = uncompressedBuffer;
+        this.compressedBuffer = compressedBuffer;
+    }
+
+    //For poison pill only
+    public TempBlock() {
+    }
+
+    public int getBytesToCompress() {
+        return bytesToCompress;
+    }
+
+    public byte[] getUncompressedBuffer() {
+        return uncompressedBuffer;
+    }
+
+    public byte[] getCompressedBuffer() {
+        return compressedBuffer;
+    }
+}

--- a/src/main/java/htsjdk/samtools/util/BlockCompressedOutputStream.java
+++ b/src/main/java/htsjdk/samtools/util/BlockCompressedOutputStream.java
@@ -23,6 +23,8 @@
  */
 package htsjdk.samtools.util;
 
+import htsjdk.samtools.model.CompressedBlock;
+import htsjdk.samtools.model.TempBlock;
 import htsjdk.samtools.util.zip.DeflaterFactory;
 
 import java.io.File;
@@ -30,6 +32,8 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.concurrent.*;
+import java.util.function.Consumer;
 import java.util.zip.CRC32;
 import java.util.zip.Deflater;
 
@@ -115,7 +119,7 @@ public class BlockCompressedOutputStream
     private Path file = null;
     private long mBlockAddress = 0;
     private GZIIndex.GZIIndexer indexer;
-
+    private CompressProducer compressProducer;
 
     // Really a local variable, but allocate once to reduce GC burden.
     private final byte[] singleByteArray = new byte[1];
@@ -175,6 +179,7 @@ public class BlockCompressedOutputStream
         this.file = path;
         codec = new BinaryCodec(path, true);
         deflater = deflaterFactory.makeDeflater(compressionLevel, true);
+        compressProducer = new CompressProducer(deflater, noCompressionDeflater, crc32, indexer, codec);
         log.debug("Using deflater: " + deflater.getClass().getSimpleName());
     }
 
@@ -241,6 +246,7 @@ public class BlockCompressedOutputStream
             codec.setOutputFileName(file.toAbsolutePath().toUri().toString());
         }
         deflater = deflaterFactory.makeDeflater(compressionLevel, true);
+        compressProducer = new CompressProducer(deflater, noCompressionDeflater, crc32, indexer, codec);
         log.debug("Using deflater: " + deflater.getClass().getSimpleName());
     }
 
@@ -302,7 +308,11 @@ public class BlockCompressedOutputStream
             numBytes -= bytesToWrite;
             assert(numBytes >= 0);
             if (numUncompressedBytes == uncompressedBuffer.length) {
-                deflateBlock();
+                if (compressProducer != null) {
+                    processBlockAsync(new TempBlock(numUncompressedBytes, uncompressedBuffer, compressedBuffer));
+                } else {
+                    processBlock(new TempBlock(numUncompressedBytes, uncompressedBuffer, compressedBuffer));
+                }
             }
         }
     }
@@ -316,7 +326,7 @@ public class BlockCompressedOutputStream
     @Override
     public void flush() throws IOException {
         while (numUncompressedBytes > 0) {
-            deflateBlock();
+            processBlock(new TempBlock(numUncompressedBytes, uncompressedBuffer, compressedBuffer));
         }
         codec.getOutputStream().flush();
     }
@@ -332,6 +342,13 @@ public class BlockCompressedOutputStream
     }
 
     public void close(final boolean writeTerminatorBlock) throws IOException {
+        if (compressProducer != null) {
+            try {
+                compressProducer.close();
+            } catch (InterruptedException e) {
+                throw new RuntimeException("Exception finishing processing by producer", e);
+            }
+        }
         flush();
         // For debugging...
         // if (numberOfThrottleBacks > 0) {
@@ -386,11 +403,43 @@ public class BlockCompressedOutputStream
      * up in the next deflate event.
      * @return size of gzip block that was written.
      */
-    private int deflateBlock() {
-        if (numUncompressedBytes == 0) {
-            return 0;
+    private void processBlock(TempBlock block) {
+        CompressedBlock compressedBlock = deflateBlock(block.getBytesToCompress(), block.getUncompressedBuffer(),
+                block.getCompressedBuffer());
+
+        // Clear out from uncompressedBuffer the data that was written
+        numUncompressedBytes = 0;
+
+        writeCompressedBlock(compressedBlock);
+    }
+
+    private void processBlockAsync(TempBlock block) {
+        try {
+            compressProducer.put(block);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
         }
-        final int bytesToCompress = numUncompressedBytes;
+    }
+
+
+
+    private void writeCompressedBlock(CompressedBlock compressedBlock) {
+        final int bytesToCompress = compressedBlock.getBytesToCompress();
+        final int totalBlockSize = writeGzipBlock(compressedBlock.getCompressedSize(), bytesToCompress, crc32.getValue(),
+                compressedBlock.getCompressedBuffer(), codec);
+
+        // Call out to the indexer if it exists
+        if (indexer != null) {
+            indexer.addGzipBlock(mBlockAddress, bytesToCompress);
+        }
+        mBlockAddress += totalBlockSize;
+    }
+
+    static CompressedBlock deflateBlock(Deflater deflater, Deflater noCompressionDeflater, CRC32 crc32,
+                                        byte[] compressedBuffer, int bytesToCompress, byte[] uncompressedBuffer) {
+        if (bytesToCompress == 0) {
+            return new CompressedBlock(0,0, new byte[0]);
+        }
         // Compress the input
         deflater.reset();
         deflater.setInput(uncompressedBuffer, 0, bytesToCompress);
@@ -412,25 +461,19 @@ public class BlockCompressedOutputStream
         crc32.reset();
         crc32.update(uncompressedBuffer, 0, bytesToCompress);
 
-        final int totalBlockSize = writeGzipBlock(compressedSize, bytesToCompress, crc32.getValue());
-        assert(bytesToCompress <= numUncompressedBytes);
+        return new CompressedBlock(compressedSize, bytesToCompress, compressedBuffer);
+    }
 
-        // Call out to the indexer if it exists
-        if (indexer != null) {
-            indexer.addGzipBlock(mBlockAddress, numUncompressedBytes);
-        }
-
-        // Clear out from uncompressedBuffer the data that was written
-        numUncompressedBytes = 0;
-        mBlockAddress += totalBlockSize;
-        return totalBlockSize;
+    private CompressedBlock deflateBlock(int bytesToCompress, byte[] uncompressedBuffer, byte[] compressedBuffer) {
+        return deflateBlock(deflater, noCompressionDeflater, crc32, compressedBuffer, bytesToCompress, uncompressedBuffer);
     }
 
     /**
      * Writes the entire gzip block, assuming the compressed data is stored in compressedBuffer
      * @return  size of gzip block that was written.
      */
-    private int writeGzipBlock(final int compressedSize, final int uncompressedSize, final long crc) {
+    static int writeGzipBlock(final int compressedSize, final int uncompressedSize, final long crc, final byte[] compressedBuffer,
+                              BinaryCodec codec) {
         // Init gzip header
         codec.writeByte(BlockCompressedStreamConstants.GZIP_ID1);
         codec.writeByte(BlockCompressedStreamConstants.GZIP_ID2);
@@ -453,4 +496,172 @@ public class BlockCompressedOutputStream
         codec.writeInt(uncompressedSize);
         return totalBlockSize;
     }
+
+    private static class CompressProducer {
+        private static final TempBlock poisonPill = new TempBlock();
+
+        private final BlockingQueue<TempBlock> resultQueue;
+        private final ExecutorService compressorExecutor;
+        private final CompressingTask compressingTask;
+
+        private CompressProducer(Deflater deflater, Deflater noCompressionDeflater, CRC32 crc32, GZIIndex.GZIIndexer indexer,
+                                 BinaryCodec codec) {
+            int compressingThreads = Runtime.getRuntime().availableProcessors();
+            int queueCapacity = compressingThreads * 2;
+            this.resultQueue = new ArrayBlockingQueue<>(queueCapacity);
+            this.compressorExecutor = Executors.newSingleThreadExecutor();
+            compressingTask = new CompressingTask(resultQueue, deflater, noCompressionDeflater, crc32, indexer, codec, compressingThreads);
+            compressorExecutor.execute(compressingTask);
+        }
+
+        public void close() throws InterruptedException {
+            compressingTask.close();
+            compressorExecutor.shutdown();
+        }
+
+        public void put(TempBlock block) throws InterruptedException {
+            resultQueue.put(block);
+        }
+
+        private static class CompressingTask implements Runnable {
+
+            private final BlockingQueue<TempBlock> resultQueue;
+            private final WriteConsumer<Future<CompressedBlock>> writeConsumer;
+            private final ExecutorService compressorExecutor;
+
+            private final Deflater deflater;
+            private final Deflater noCompressionDeflater;
+
+            private final CRC32 crc32;
+            private GZIIndex.GZIIndexer indexer;
+            private final BinaryCodec codec;
+            private long mBlockAddress = 0;
+
+
+            private CompressingTask(BlockingQueue<TempBlock> resultQueue, Deflater deflater, Deflater noCompressionDeflater, CRC32 crc32,
+                                    GZIIndex.GZIIndexer indexer, BinaryCodec codec, int nThreads) {
+                this.resultQueue = resultQueue;
+                this.deflater = deflater;
+                this.noCompressionDeflater = noCompressionDeflater;
+                this.crc32 = crc32;
+                this.indexer = indexer;
+                this.codec = codec;
+
+                compressorExecutor = Executors.newFixedThreadPool(nThreads);
+                writeConsumer = makeWriteConsumer();
+            }
+
+            public void close() throws InterruptedException {
+                resultQueue.put(poisonPill);
+                compressorExecutor.shutdown();
+                writeConsumer.close();
+            }
+
+            private WriteConsumer<Future<CompressedBlock>> makeWriteConsumer() {
+                return new WriteConsumer<>(this::writeCompressedBlock);
+            }
+
+            private void writeCompressedBlock(Future<CompressedBlock> compressedBlockFuture) {
+                try {
+                    writeCompressedBlock(compressedBlockFuture.get());
+                } catch (InterruptedException | ExecutionException e) {
+                    throw new RuntimeException("CompressedBlock hasn't written", e);
+                }
+            }
+
+            private void writeCompressedBlock(CompressedBlock compressedBlock) {
+                final int bytesToCompress = compressedBlock.getBytesToCompress();
+                final int totalBlockSize = writeGzipBlock(compressedBlock.getCompressedSize(), bytesToCompress, crc32.getValue(),
+                        compressedBlock.getCompressedBuffer(), codec);
+
+                // Call out to the indexer if it exists
+                if (indexer != null) {
+                    indexer.addGzipBlock(mBlockAddress, bytesToCompress);
+                }
+                mBlockAddress += totalBlockSize;
+            }
+
+            private CompressedBlock compressBlock(TempBlock block) {
+                return deflateBlock(deflater, noCompressionDeflater, crc32, block.getCompressedBuffer(), block.getBytesToCompress(),
+                        block.getUncompressedBuffer());
+            }
+
+            @Override
+            public void run() {
+                boolean isNotInterrupted = true;
+                while (isNotInterrupted) {
+                    try {
+                        TempBlock block = resultQueue.take();
+                        if (block == poisonPill) {
+                            break;
+                        }
+
+                        writeConsumer.put(compressorExecutor.submit(() -> compressBlock(block)));
+                    } catch (InterruptedException e) {
+                        isNotInterrupted = false;
+                        log.error(e,"CompressingTask has interrupted");
+                    }
+                }
+            }
+        }
+    }
+
+    private static class WriteConsumer<T> {
+        private final BlockingQueue<T> resultQueue;
+        private final ExecutorService writerExecutor;
+        private final CountDownLatch downLatch;
+        private static final CompressedBlock poisonPill = new CompressedBlock();
+
+        private WriteConsumer(Consumer<T> consumer) {
+            this.resultQueue = new ArrayBlockingQueue<>(24);
+            this.downLatch = new CountDownLatch(1);
+            this.writerExecutor = Executors.newSingleThreadExecutor();
+
+            writerExecutor.execute(new WritingTask<>(resultQueue, consumer, downLatch));
+            writerExecutor.shutdown();
+        }
+
+        public void close() throws InterruptedException {
+            resultQueue.put((T) poisonPill);
+            downLatch.await();
+            writerExecutor.shutdown();
+        }
+
+        public void put(T t) throws InterruptedException {
+            resultQueue.put(t);
+        }
+
+        private static class WritingTask<T> implements Runnable {
+
+            private final BlockingQueue<T> futuresQueue;
+            private final Consumer<T> consumer;
+            private final CountDownLatch latch;
+
+            private WritingTask(BlockingQueue<T> futuresQueue, Consumer<T> consumer, CountDownLatch latch) {
+                this.futuresQueue = futuresQueue;
+                this.consumer = consumer;
+                this.latch = latch;
+            }
+
+            @Override
+            public void run() {
+                boolean isNotInterrupted = true;
+                while (isNotInterrupted) {
+                    try {
+                        T compressedBlock = futuresQueue.take();
+                        if (compressedBlock == poisonPill) {
+                            break;
+                        }
+
+                        consumer.accept(compressedBlock);
+                    } catch (InterruptedException e) {
+                        isNotInterrupted = false;
+                        log.error(e,"WritingTask has interrupted");
+                    }
+                }
+                latch.countDown();
+            }
+        }
+    }
+
 }

--- a/src/main/java/htsjdk/samtools/util/async/CompressProducer.java
+++ b/src/main/java/htsjdk/samtools/util/async/CompressProducer.java
@@ -1,0 +1,125 @@
+package htsjdk.samtools.util.async;
+
+import htsjdk.samtools.model.CompressedBlock;
+import htsjdk.samtools.model.TempBlock;
+import htsjdk.samtools.util.BinaryCodec;
+import htsjdk.samtools.util.BlockCompressedOutputStream;
+import htsjdk.samtools.util.GZIIndex;
+import htsjdk.samtools.util.Log;
+
+import java.util.concurrent.*;
+import java.util.zip.CRC32;
+import java.util.zip.Deflater;
+
+public class CompressProducer {
+
+    private static final Log log = Log.getInstance(CompressProducer.class);
+    private static final TempBlock poisonPill = new TempBlock();
+
+    private final BlockingQueue<TempBlock> resultQueue;
+    private final ExecutorService compressorExecutor;
+    private final CompressingTask compressingTask;
+
+    public CompressProducer(Deflater deflater, Deflater noCompressionDeflater, CRC32 crc32, GZIIndex.GZIIndexer indexer,
+                            BinaryCodec codec) {
+        int compressingThreads = Runtime.getRuntime().availableProcessors();
+        int queueCapacity = compressingThreads * 2;
+        this.resultQueue = new ArrayBlockingQueue<>(queueCapacity);
+        this.compressorExecutor = Executors.newSingleThreadExecutor();
+
+        compressingTask = new CompressingTask(resultQueue, deflater, noCompressionDeflater, crc32, indexer, codec,
+                queueCapacity, compressingThreads);
+        compressorExecutor.execute(compressingTask);
+    }
+
+    public void close() throws InterruptedException {
+        compressingTask.close();
+        compressorExecutor.shutdown();
+    }
+
+    public void put(TempBlock block) throws InterruptedException {
+        resultQueue.put(block);
+    }
+
+    private static class CompressingTask implements Runnable {
+
+        private final BlockingQueue<TempBlock> resultQueue;
+        private final WriteConsumer writeConsumer;
+        private final ExecutorService compressorExecutor;
+
+        private final Deflater deflater;
+        private final Deflater noCompressionDeflater;
+
+        private final CRC32 crc32;
+        private final GZIIndex.GZIIndexer indexer;
+        private final BinaryCodec codec;
+        private long mBlockAddress = 0;
+
+        private CompressingTask(BlockingQueue<TempBlock> resultQueue, Deflater deflater, Deflater noCompressionDeflater, CRC32 crc32,
+                                GZIIndex.GZIIndexer indexer, BinaryCodec codec, int queueCapacity, int nThreads) {
+            this.resultQueue = resultQueue;
+            this.deflater = deflater;
+            this.noCompressionDeflater = noCompressionDeflater;
+            this.crc32 = crc32;
+            this.indexer = indexer;
+            this.codec = codec;
+
+            compressorExecutor = Executors.newFixedThreadPool(nThreads);
+            writeConsumer = makeWriteConsumer(queueCapacity);
+        }
+
+        public void close() throws InterruptedException {
+            resultQueue.put(poisonPill);
+            writeConsumer.close();
+
+            compressorExecutor.shutdown();
+            try {
+                if (!compressorExecutor.awaitTermination(800, TimeUnit.MILLISECONDS)) {
+                    compressorExecutor.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                compressorExecutor.shutdownNow();
+            }
+        }
+
+        private WriteConsumer makeWriteConsumer(int queueCapacity) {
+            return new WriteConsumer(this::writeCompressedBlock, queueCapacity);
+        }
+
+        private void writeCompressedBlock(CompressedBlock compressedBlock) {
+            final int bytesToCompress = compressedBlock.getBytesToCompress();
+            final int totalBlockSize = BlockCompressedOutputStream.writeGzipBlock(compressedBlock.getCompressedSize(), bytesToCompress,
+                    crc32.getValue(),
+                    compressedBlock.getCompressedBuffer(), codec);
+
+            // Call out to the indexer if it exists
+            if (indexer != null) {
+                indexer.addGzipBlock(mBlockAddress, bytesToCompress);
+            }
+            mBlockAddress += totalBlockSize;
+        }
+
+        private CompressedBlock compressBlock(TempBlock block) {
+            return BlockCompressedOutputStream.deflateBlock(deflater, noCompressionDeflater, crc32, block.getCompressedBuffer(),
+                    block.getBytesToCompress(), block.getUncompressedBuffer());
+        }
+
+        @Override
+        public void run() {
+            boolean isNotInterrupted = true;
+            while (isNotInterrupted) {
+                try {
+                    TempBlock block = resultQueue.take();
+                    if (block == poisonPill) {
+                        break;
+                    }
+
+                    writeConsumer.put(compressorExecutor.submit(() -> compressBlock(block)));
+                } catch (InterruptedException e) {
+                    isNotInterrupted = false;
+                    log.error(e, "CompressingTask was interrupted");
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/htsjdk/samtools/util/async/WriteConsumer.java
+++ b/src/main/java/htsjdk/samtools/util/async/WriteConsumer.java
@@ -1,0 +1,66 @@
+package htsjdk.samtools.util.async;
+
+import htsjdk.samtools.model.CompressedBlock;
+import htsjdk.samtools.util.Log;
+
+import java.util.concurrent.*;
+import java.util.function.Consumer;
+
+public class WriteConsumer {
+
+    private static final Log log = Log.getInstance(WriteConsumer.class);
+    private static final CompressedBlock poisonPill = new CompressedBlock();
+
+    private final BlockingQueue<CompressedBlock> resultQueue;
+    private final ExecutorService writerExecutor;
+
+    public WriteConsumer(Consumer<CompressedBlock> consumer, int queueCapacity) {
+        this.resultQueue = new ArrayBlockingQueue<>(1000);
+        this.writerExecutor = Executors.newSingleThreadExecutor();
+
+        writerExecutor.execute(new WritingTask(resultQueue, consumer));
+        writerExecutor.shutdown();
+    }
+
+    public void close() throws InterruptedException {
+        resultQueue.put(poisonPill);
+        writerExecutor.shutdownNow();
+    }
+
+    public void put(Future<CompressedBlock> t) throws InterruptedException {
+        try {
+            resultQueue.put(t.get());
+        } catch (ExecutionException e) {
+            throw new RuntimeException("WriteConsumer.put()", e);
+        }
+    }
+
+    private static class WritingTask implements Runnable {
+
+        private final BlockingQueue<CompressedBlock> futuresQueue;
+        private final Consumer<CompressedBlock> consumer;
+
+        private WritingTask(BlockingQueue<CompressedBlock> futuresQueue, Consumer<CompressedBlock> consumer) {
+            this.futuresQueue = futuresQueue;
+            this.consumer = consumer;
+        }
+
+        @Override
+        public void run() {
+            boolean isNotInterrupted = true;
+            while (isNotInterrupted) {
+                try {
+                    CompressedBlock compressedBlock = futuresQueue.take();
+                    if (compressedBlock == poisonPill) {
+                        break;
+                    }
+
+                    consumer.accept(compressedBlock);
+                } catch (InterruptedException e) {
+                    isNotInterrupted = false;
+                    log.error(e, "WritingTask was interrupted");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Multithreading Produces-Consumer implementation of BlockCompressedOutptuStream.

Here are also performance result SortSam where BlockCompressedOutputStream is used:
### Inputfile: 96,1mb (~20% profit)
#### master:
```
Benchmark                            (bufferSize)  Mode  Cnt      Score   Error  Units
SamBenchMark.sortingBufferParameter         50000    ss       12140.642          ms/op
SamBenchMark.sortingBufferParameter        100000    ss       11656.378          ms/op
SamBenchMark.sortingBufferParameter        400000    ss       12310.376          ms/op
SamBenchMark.sortingBufferParameter        500000    ss       12052.047          ms/op
SamBenchMark.sortingBufferParameter       1000000    ss       12575.294          ms/op
SamBenchMark.sortingBufferParameter       1500000    ss       12129.808          ms/op
SamBenchMark.sortingBufferParameter       2000000    ss       10250.480          ms/op
SamBenchMark.sortingBufferParameter       2500000    ss       10288.553          ms/op
```

#### DeflateBlockAsync:
```
Benchmark                            (bufferSize)  Mode  Cnt      Score   Error  Units
SamBenchMark.sortingBufferParameter         50000    ss        9566.487          ms/op
SamBenchMark.sortingBufferParameter        100000    ss        9596.872          ms/op
SamBenchMark.sortingBufferParameter        400000    ss       10435.730          ms/op
SamBenchMark.sortingBufferParameter        500000    ss       10146.578          ms/op
SamBenchMark.sortingBufferParameter       1000000    ss       11094.997          ms/op
SamBenchMark.sortingBufferParameter       1500000    ss       10497.976          ms/op
SamBenchMark.sortingBufferParameter       2000000    ss        8809.046          ms/op
SamBenchMark.sortingBufferParameter       2500000    ss        8691.569          ms/op
```

### Inputfile: 947,9mb (~10% profit)
#### master:
```
Benchmark                            (bufferSize)  Mode  Cnt       Score   Error  Units
SamBenchMark.sortingBufferParameter         50000    ss       113631.729          ms/op
SamBenchMark.sortingBufferParameter        100000    ss       113185.477          ms/op
SamBenchMark.sortingBufferParameter        400000    ss       122839.217          ms/op
SamBenchMark.sortingBufferParameter        500000    ss       114307.357          ms/op
SamBenchMark.sortingBufferParameter       1000000    ss       116134.463          ms/op
SamBenchMark.sortingBufferParameter       1500000    ss       117954.202          ms/op
SamBenchMark.sortingBufferParameter       2000000    ss       117627.674          ms/op
SamBenchMark.sortingBufferParameter       2500000    ss       118221.354          ms/op
```

#### DeflateBlockAsync:
```
Benchmark                            (bufferSize)  Mode  Cnt       Score   Error  Units
SamBenchMark.sortingBufferParameter         50000    ss       103967.468          ms/op
SamBenchMark.sortingBufferParameter        100000    ss       102129.136          ms/op
SamBenchMark.sortingBufferParameter        400000    ss       103482.666          ms/op
SamBenchMark.sortingBufferParameter        500000    ss       102251.986          ms/op
SamBenchMark.sortingBufferParameter       1000000    ss       105603.646          ms/op
SamBenchMark.sortingBufferParameter       1500000    ss       104050.596          ms/op
SamBenchMark.sortingBufferParameter       2000000    ss       106393.765          ms/op
SamBenchMark.sortingBufferParameter       2500000    ss       105996.162          ms/op
```