### PR TITLE
AsyncBlockCompressedOutputStream

### DIFF
--- a/src/main/java/htsjdk/samtools/BAMFileWriter.java
+++ b/src/main/java/htsjdk/samtools/BAMFileWriter.java
@@ -28,6 +28,8 @@ import htsjdk.samtools.util.BlockCompressedOutputStream;
 import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.RuntimeIOException;
+import htsjdk.samtools.util.output.AbstractBlockCompressedOutputStream;
+import htsjdk.samtools.util.output.async.AsyncBlockCompressedOutputStream;
 import htsjdk.samtools.util.zip.DeflaterFactory;
 
 import java.io.File;
@@ -45,43 +47,51 @@ public class BAMFileWriter extends SAMFileWriterImpl {
 
     private final BinaryCodec outputBinaryCodec;
     private BAMRecordCodec bamRecordCodec = null;
-    private final BlockCompressedOutputStream blockCompressedOutputStream;
+    private final AbstractBlockCompressedOutputStream blockCompressedOutputStream;
     private BAMIndexer bamIndexer = null;
 
-    protected BAMFileWriter(final File path) {
-        blockCompressedOutputStream = new BlockCompressedOutputStream(path);
+    protected BAMFileWriter(final File path, boolean asyncCompressedOutputStream) {
+        blockCompressedOutputStream = asyncCompressedOutputStream ? new AsyncBlockCompressedOutputStream(path) :
+                new BlockCompressedOutputStream(path);
         outputBinaryCodec = new BinaryCodec(blockCompressedOutputStream);
         outputBinaryCodec.setOutputFileName(path.getAbsolutePath());
     }
 
-    protected BAMFileWriter(final File path, final int compressionLevel) {
-        blockCompressedOutputStream = new BlockCompressedOutputStream(path, compressionLevel);
+    protected BAMFileWriter(final File path, final int compressionLevel, boolean asyncCompressedOutputStream) {
+        blockCompressedOutputStream = asyncCompressedOutputStream ? new AsyncBlockCompressedOutputStream(path, compressionLevel) :
+                new BlockCompressedOutputStream(path, compressionLevel);
         outputBinaryCodec = new BinaryCodec(blockCompressedOutputStream);
         outputBinaryCodec.setOutputFileName(path.getAbsolutePath());
     }
 
-    protected BAMFileWriter(final OutputStream os, final File file) {
-        blockCompressedOutputStream = new BlockCompressedOutputStream(os, file);
+    protected BAMFileWriter(final OutputStream os, final File file, boolean asyncCompressedOutputStream) {
+        blockCompressedOutputStream = asyncCompressedOutputStream ? new AsyncBlockCompressedOutputStream(os, IOUtil.toPath(file)) :
+                new BlockCompressedOutputStream(os, file);
         outputBinaryCodec = new BinaryCodec(blockCompressedOutputStream);
         outputBinaryCodec.setOutputFileName(getPathString(file));
     }
 
-    protected BAMFileWriter(final OutputStream os, final File file, final int compressionLevel) {
-        blockCompressedOutputStream = new BlockCompressedOutputStream(os, file, compressionLevel);
+    protected BAMFileWriter(final OutputStream os, final File file, final int compressionLevel, boolean asyncCompressedOutputStream) {
+        blockCompressedOutputStream = asyncCompressedOutputStream ? new AsyncBlockCompressedOutputStream(os, IOUtil.toPath(file),
+                compressionLevel) : new BlockCompressedOutputStream(os, file, compressionLevel);
         outputBinaryCodec = new BinaryCodec(blockCompressedOutputStream);
         outputBinaryCodec.setOutputFileName(getPathString(file));
     }
 
-    protected BAMFileWriter(final OutputStream os, final File file, final int compressionLevel, final DeflaterFactory deflaterFactory) {
-        blockCompressedOutputStream = new BlockCompressedOutputStream(os, file, compressionLevel, deflaterFactory);
+    protected BAMFileWriter(final OutputStream os, final File file, final int compressionLevel, final DeflaterFactory deflaterFactory,
+                            boolean asyncCompressedOutputStream) {
+        blockCompressedOutputStream = asyncCompressedOutputStream ? new AsyncBlockCompressedOutputStream(os, IOUtil.toPath(file),
+                compressionLevel, deflaterFactory) : new BlockCompressedOutputStream(os, file, compressionLevel, deflaterFactory);
         outputBinaryCodec = new BinaryCodec(blockCompressedOutputStream);
         outputBinaryCodec.setOutputFileName(getPathString(file));
     }
 
-    protected BAMFileWriter(final OutputStream os, final String absoluteFilename, final int compressionLevel, final DeflaterFactory deflaterFactory) {
-      blockCompressedOutputStream = new BlockCompressedOutputStream(os, (Path)null, compressionLevel, deflaterFactory);
-      outputBinaryCodec = new BinaryCodec(blockCompressedOutputStream);
-      outputBinaryCodec.setOutputFileName(absoluteFilename);
+    protected BAMFileWriter(final OutputStream os, final String absoluteFilename, final int compressionLevel,
+                            final DeflaterFactory deflaterFactory, boolean asyncCompressedOutputStream) {
+        blockCompressedOutputStream = asyncCompressedOutputStream ? new AsyncBlockCompressedOutputStream(os, null, compressionLevel,
+                deflaterFactory) : new BlockCompressedOutputStream(os, (Path) null, compressionLevel, deflaterFactory);
+        outputBinaryCodec = new BinaryCodec(blockCompressedOutputStream);
+        outputBinaryCodec.setOutputFileName(absoluteFilename);
     }
 
   private void prepareToWriteAlignments() {

--- a/src/main/java/htsjdk/samtools/Defaults.java
+++ b/src/main/java/htsjdk/samtools/Defaults.java
@@ -110,6 +110,11 @@ public class Defaults {
      */
     public static final boolean DISABLE_SNAPPY_COMPRESSOR;
 
+    /**
+     * AsyncBlockCompressedOutputStream asynchronous write.
+     * Default = true.
+     */
+    public static final boolean USE_ASYNC_COMPRESSED_OUTPUT_STREAM;
 
     public static final String SAMJDK_PREFIX = "samjdk.";
     static {
@@ -134,6 +139,7 @@ public class Defaults {
         SAM_FLAG_FIELD_FORMAT = SamFlagField.valueOf(getStringProperty("sam_flag_field_format", SamFlagField.DECIMAL.name()));
         SRA_LIBRARIES_DOWNLOAD = getBooleanProperty("sra_libraries_download", false);
         DISABLE_SNAPPY_COMPRESSOR = getBooleanProperty(DISABLE_SNAPPY_PROPERTY_NAME, false);
+        USE_ASYNC_COMPRESSED_OUTPUT_STREAM = getBooleanProperty("use_async_compressed_output_stream", false);
     }
 
     /**
@@ -157,6 +163,7 @@ public class Defaults {
         result.put("CUSTOM_READER_FACTORY", CUSTOM_READER_FACTORY);
         result.put("SAM_FLAG_FIELD_FORMAT", SAM_FLAG_FIELD_FORMAT);
         result.put("DISABLE_SNAPPY_COMPRESSOR", DISABLE_SNAPPY_COMPRESSOR);
+        result.put("USE_ASYNC_COMPRESSED_OUTPUT_STREAM", USE_ASYNC_COMPRESSED_OUTPUT_STREAM);
         return Collections.unmodifiableSortedMap(result);
     }
 

--- a/src/main/java/htsjdk/samtools/util/BlockCompressedOutputStream.java
+++ b/src/main/java/htsjdk/samtools/util/BlockCompressedOutputStream.java
@@ -23,12 +23,12 @@
  */
 package htsjdk.samtools.util;
 
+import htsjdk.samtools.util.output.AbstractBlockCompressedOutputStream;
 import htsjdk.samtools.util.zip.DeflaterFactory;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.zip.CRC32;
 import java.util.zip.Deflater;
@@ -48,51 +48,11 @@ import java.util.zip.Deflater;
  *
  * c.f. http://samtools.sourceforge.net/SAM1.pdf for details of BGZF file format.
  */
-public class BlockCompressedOutputStream
-        extends OutputStream
-        implements LocationAware
+public class BlockCompressedOutputStream extends AbstractBlockCompressedOutputStream
 {
 
     private static final Log log = Log.getInstance(BlockCompressedOutputStream.class);
 
-    private static int defaultCompressionLevel = BlockCompressedStreamConstants.DEFAULT_COMPRESSION_LEVEL;
-    private static DeflaterFactory defaultDeflaterFactory = new DeflaterFactory();
-
-    /**
-     * Sets the GZip compression level for subsequent BlockCompressedOutputStream object creation
-     * that do not specify the compression level.
-     * @param compressionLevel 1 <= compressionLevel <= 9
-     */
-    public static void setDefaultCompressionLevel(final int compressionLevel) {
-        if (compressionLevel < Deflater.NO_COMPRESSION || compressionLevel > Deflater.BEST_COMPRESSION) {
-            throw new IllegalArgumentException("Invalid compression level: " + compressionLevel);
-        }
-        defaultCompressionLevel = compressionLevel;
-    }
-
-    public static int getDefaultCompressionLevel() {
-        return defaultCompressionLevel;
-    }
-
-    /**
-     * Sets the default {@link DeflaterFactory} that will be used for all instances unless specified otherwise in the constructor.
-     * If this method is not called the default is a factory that will create the JDK {@link Deflater}.
-     * @param deflaterFactory non-null default factory.
-     */
-    public static void setDefaultDeflaterFactory(final DeflaterFactory deflaterFactory) {
-        if (deflaterFactory == null) {
-            throw new IllegalArgumentException("null deflaterFactory");
-        }
-        defaultDeflaterFactory = deflaterFactory;
-    }
-
-    public static DeflaterFactory getDefaultDeflaterFactory() {
-        return defaultDeflaterFactory;
-    }
-
-    private final BinaryCodec codec;
-    private final byte[] uncompressedBuffer = new byte[BlockCompressedStreamConstants.DEFAULT_UNCOMPRESSED_BLOCK_SIZE];
-    private int numUncompressedBytes = 0;
     private final byte[] compressedBuffer =
             new byte[BlockCompressedStreamConstants.MAX_COMPRESSED_BLOCK_SIZE -
                     BlockCompressedStreamConstants.BLOCK_HEADER_LENGTH];
@@ -112,13 +72,6 @@ public class BlockCompressedOutputStream
     // so just use JDK standard.
     private final Deflater noCompressionDeflater = new Deflater(Deflater.NO_COMPRESSION, true);
     private final CRC32 crc32 = new CRC32();
-    private Path file = null;
-    private long mBlockAddress = 0;
-    private GZIIndex.GZIIndexer indexer;
-
-
-    // Really a local variable, but allocate once to reduce GC burden.
-    private final byte[] singleByteArray = new byte[1];
 
     /**
      * Uses default compression level, which is 5 unless changed by setCompressionLevel
@@ -172,8 +125,7 @@ public class BlockCompressedOutputStream
      * @param deflaterFactory custom factory to create deflaters (overrides the default)
      */
     public BlockCompressedOutputStream(final Path path, final int compressionLevel, final DeflaterFactory deflaterFactory) {
-        this.file = path;
-        codec = new BinaryCodec(path, true);
+        super(path);
         deflater = deflaterFactory.makeDeflater(compressionLevel, true);
         log.debug("Using deflater: " + deflater.getClass().getSimpleName());
     }
@@ -235,11 +187,7 @@ public class BlockCompressedOutputStream
      * @param deflaterFactory custom factory to create deflaters (overrides the default)
      */
     public BlockCompressedOutputStream(final OutputStream os, final Path file, final int compressionLevel, final DeflaterFactory deflaterFactory) {
-        this.file = file;
-        codec = new BinaryCodec(os);
-        if (file != null) {
-            codec.setOutputFileName(file.toAbsolutePath().toUri().toString());
-        }
+        super(os, file);
         deflater = deflaterFactory.makeDeflater(compressionLevel, true);
         log.debug("Using deflater: " + deflater.getClass().getSimpleName());
     }
@@ -273,55 +221,6 @@ public class BlockCompressedOutputStream
     }
 
     /**
-     * Writes b.length bytes from the specified byte array to this output stream. The general contract for write(b)
-     * is that it should have exactly the same effect as the call write(b, 0, b.length).
-     * @param bytes the data
-     */
-    @Override
-    public void write(final byte[] bytes) throws IOException {
-        write(bytes, 0, bytes.length);
-    }
-
-    /**
-     * Writes len bytes from the specified byte array starting at offset off to this output stream. The general
-     * contract for write(b, off, len) is that some of the bytes in the array b are written to the output stream in order;
-     * element b[off] is the first byte written and b[off+len-1] is the last byte written by this operation.
-     *
-     * @param bytes the data
-     * @param startIndex the start offset in the data
-     * @param numBytes the number of bytes to write
-     */
-    @Override
-    public void write(final byte[] bytes, int startIndex, int numBytes) throws IOException {
-        assert(numUncompressedBytes < uncompressedBuffer.length);
-        while (numBytes > 0) {
-            final int bytesToWrite = Math.min(uncompressedBuffer.length - numUncompressedBytes, numBytes);
-            System.arraycopy(bytes, startIndex, uncompressedBuffer, numUncompressedBytes, bytesToWrite);
-            numUncompressedBytes += bytesToWrite;
-            startIndex += bytesToWrite;
-            numBytes -= bytesToWrite;
-            assert(numBytes >= 0);
-            if (numUncompressedBytes == uncompressedBuffer.length) {
-                deflateBlock();
-            }
-        }
-    }
-
-    /**
-     * WARNING: flush() affects the output format, because it causes the current contents of uncompressedBuffer
-     * to be compressed and written, even if it isn't full.  Unless you know what you're doing, don't call flush().
-     * Instead, call close(), which will flush any unwritten data before closing the underlying stream.
-     *
-     */
-    @Override
-    public void flush() throws IOException {
-        while (numUncompressedBytes > 0) {
-            deflateBlock();
-        }
-        codec.getOutputStream().flush();
-    }
-
-    /**
      * close() must be called in order to flush any remaining buffered bytes.  An unclosed file will likely be
      * defective.
      *
@@ -331,64 +230,16 @@ public class BlockCompressedOutputStream
         close(true);
     }
 
-    public void close(final boolean writeTerminatorBlock) throws IOException {
-        flush();
-        // For debugging...
-        // if (numberOfThrottleBacks > 0) {
-        //     System.err.println("In BlockCompressedOutputStream, had to throttle back " + numberOfThrottleBacks +
-        //                        " times for file " + codec.getOutputFileName());
-        // }
-        if (writeTerminatorBlock) {
-            codec.writeBytes(BlockCompressedStreamConstants.EMPTY_GZIP_BLOCK);
-        }
-        codec.close();
-        if (indexer != null) {
-            indexer.close();
-        }
-        // Can't re-open something that is not a regular file, e.g. a named pipe or an output stream
-        if (this.file == null || !Files.isRegularFile(this.file)) return;
-        if (BlockCompressedInputStream.checkTermination(this.file) !=
-                BlockCompressedInputStream.FileTermination.HAS_TERMINATOR_BLOCK) {
-            throw new IOException("Terminator block not found after closing BGZF file " + this.file);
-        }
-    }
-
-    /**
-     * Writes the specified byte to this output stream. The general contract for write is that one byte is written
-     * to the output stream. The byte to be written is the eight low-order bits of the argument b.
-     * The 24 high-order bits of b are ignored.
-     * @param bite
-     * @throws IOException
-     */
-    @Override
-    public void write(final int bite) throws IOException {
-        singleByteArray[0] = (byte)bite;
-        write(singleByteArray);
-    }
-
-    /** Encode virtual file pointer
-     * Upper 48 bits is the byte offset into the compressed stream of a block.
-     * Lower 16 bits is the byte offset into the uncompressed stream inside the block.
-     */
-    public long getFilePointer(){
-        return BlockCompressedFilePointerUtil.makeFilePointer(mBlockAddress, numUncompressedBytes);
-    }
-
-    @Override
-    public long getPosition() {
-        return getFilePointer();
-    }
-
     /**
      * Attempt to write the data in uncompressedBuffer to the underlying file in a gzip block.
      * If the entire uncompressedBuffer does not fit in the maximum allowed size, reduce the amount
      * of data to be compressed, and slide the excess down in uncompressedBuffer so it can be picked
      * up in the next deflate event.
-     * @return size of gzip block that was written.
      */
-    private int deflateBlock() {
+    @Override
+    protected void deflateBlock() {
         if (numUncompressedBytes == 0) {
-            return 0;
+            return;
         }
         final int bytesToCompress = numUncompressedBytes;
         // Compress the input
@@ -412,7 +263,7 @@ public class BlockCompressedOutputStream
         crc32.reset();
         crc32.update(uncompressedBuffer, 0, bytesToCompress);
 
-        final int totalBlockSize = writeGzipBlock(compressedSize, bytesToCompress, crc32.getValue());
+        final int totalBlockSize = writeGzipBlock(compressedBuffer, compressedSize, bytesToCompress, crc32.getValue());
         assert(bytesToCompress <= numUncompressedBytes);
 
         // Call out to the indexer if it exists
@@ -423,34 +274,5 @@ public class BlockCompressedOutputStream
         // Clear out from uncompressedBuffer the data that was written
         numUncompressedBytes = 0;
         mBlockAddress += totalBlockSize;
-        return totalBlockSize;
-    }
-
-    /**
-     * Writes the entire gzip block, assuming the compressed data is stored in compressedBuffer
-     * @return  size of gzip block that was written.
-     */
-    private int writeGzipBlock(final int compressedSize, final int uncompressedSize, final long crc) {
-        // Init gzip header
-        codec.writeByte(BlockCompressedStreamConstants.GZIP_ID1);
-        codec.writeByte(BlockCompressedStreamConstants.GZIP_ID2);
-        codec.writeByte(BlockCompressedStreamConstants.GZIP_CM_DEFLATE);
-        codec.writeByte(BlockCompressedStreamConstants.GZIP_FLG);
-        codec.writeInt(0); // Modification time
-        codec.writeByte(BlockCompressedStreamConstants.GZIP_XFL);
-        codec.writeByte(BlockCompressedStreamConstants.GZIP_OS_UNKNOWN);
-        codec.writeShort(BlockCompressedStreamConstants.GZIP_XLEN);
-        codec.writeByte(BlockCompressedStreamConstants.BGZF_ID1);
-        codec.writeByte(BlockCompressedStreamConstants.BGZF_ID2);
-        codec.writeShort(BlockCompressedStreamConstants.BGZF_LEN);
-        final int totalBlockSize = compressedSize + BlockCompressedStreamConstants.BLOCK_HEADER_LENGTH +
-                BlockCompressedStreamConstants.BLOCK_FOOTER_LENGTH;
-
-        // I don't know why we store block size - 1, but that is what the spec says
-        codec.writeShort((short)(totalBlockSize - 1));
-        codec.writeBytes(compressedBuffer, 0, compressedSize);
-        codec.writeInt((int)crc);
-        codec.writeInt(uncompressedSize);
-        return totalBlockSize;
     }
 }

--- a/src/main/java/htsjdk/samtools/util/output/AbstractBlockCompressedOutputStream.java
+++ b/src/main/java/htsjdk/samtools/util/output/AbstractBlockCompressedOutputStream.java
@@ -1,0 +1,209 @@
+package htsjdk.samtools.util.output;
+
+import htsjdk.samtools.util.*;
+import htsjdk.samtools.util.zip.DeflaterFactory;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.Deflater;
+
+public abstract class AbstractBlockCompressedOutputStream extends OutputStream implements LocationAware {
+
+    protected static int defaultCompressionLevel = BlockCompressedStreamConstants.DEFAULT_COMPRESSION_LEVEL;
+    protected static DeflaterFactory defaultDeflaterFactory = new DeflaterFactory();
+
+    protected final BinaryCodec codec;
+    protected final byte[] uncompressedBuffer = new byte[BlockCompressedStreamConstants.DEFAULT_UNCOMPRESSED_BLOCK_SIZE];
+    protected int numUncompressedBytes = 0;
+
+    protected Path file;
+    protected long mBlockAddress = 0;
+    protected GZIIndex.GZIIndexer indexer;
+
+    // Really a local variable, but allocate once to reduce GC burden.
+    protected final byte[] singleByteArray = new byte[1];
+
+    /**
+     * Uses default compression level, which is 5 unless changed by setCompressionLevel
+     * Note: this constructor uses the default {@link DeflaterFactory}, see {@link #getDefaultDeflaterFactory()}.
+     */
+    public AbstractBlockCompressedOutputStream(final Path file) {
+        this.file = file;
+        codec = new BinaryCodec(file, true);
+    }
+
+    public AbstractBlockCompressedOutputStream(final OutputStream os, final Path file) {
+        this.file = file;
+        codec = new BinaryCodec(os);
+        if (file != null) {
+            codec.setOutputFileName(file.toAbsolutePath().toUri().toString());
+        }
+    }
+
+    /**
+     * Writes b.length bytes from the specified byte array to this output stream. The general contract for write(b)
+     * is that it should have exactly the same effect as the call write(b, 0, b.length).
+     * @param bytes the data
+     */
+    @Override
+    public void write(final byte[] bytes) throws IOException {
+        write(bytes, 0, bytes.length);
+    }
+
+    /**
+     * Writes len bytes from the specified byte array starting at offset off to this output stream. The general
+     * contract for write(b, off, len) is that some of the bytes in the array b are written to the output stream in order;
+     * element b[off] is the first byte written and b[off+len-1] is the last byte written by this operation.
+     *
+     * @param bytes the data
+     * @param startIndex the start offset in the data
+     * @param numBytes the number of bytes to write
+     */
+    @Override
+    public void write(final byte[] bytes, int startIndex, int numBytes) throws IOException {
+        assert(numUncompressedBytes < uncompressedBuffer.length);
+        while (numBytes > 0) {
+            final int bytesToWrite = Math.min(uncompressedBuffer.length - numUncompressedBytes, numBytes);
+            System.arraycopy(bytes, startIndex, uncompressedBuffer, numUncompressedBytes, bytesToWrite);
+            numUncompressedBytes += bytesToWrite;
+            startIndex += bytesToWrite;
+            numBytes -= bytesToWrite;
+            assert(numBytes >= 0);
+            if (numUncompressedBytes == uncompressedBuffer.length) {
+                deflateBlock();
+            }
+        }
+    }
+
+    /**
+     * WARNING: flush() affects the output format, because it causes the current contents of uncompressedBuffer
+     * to be compressed and written, even if it isn't full.  Unless you know what you're doing, don't call flush().
+     * Instead, call close(), which will flush any unwritten data before closing the underlying stream.
+     *
+     */
+    @Override
+    public void flush() throws IOException {
+        while (numUncompressedBytes > 0) {
+            deflateBlock();
+        }
+        codec.getOutputStream().flush();
+    }
+
+    public void close(final boolean writeTerminatorBlock) throws IOException {
+        flush();
+        // For debugging...
+        // if (numberOfThrottleBacks > 0) {
+        //     System.err.println("In BlockCompressedOutputStream, had to throttle back " + numberOfThrottleBacks +
+        //                        " times for file " + codec.getOutputFileName());
+        // }
+        if (writeTerminatorBlock) {
+            codec.writeBytes(BlockCompressedStreamConstants.EMPTY_GZIP_BLOCK);
+        }
+        codec.close();
+        if (indexer != null) {
+            indexer.close();
+        }
+        // Can't re-open something that is not a regular file, e.g. a named pipe or an output stream
+        if (this.file == null || !Files.isRegularFile(this.file)) return;
+        if (BlockCompressedInputStream.checkTermination(this.file) !=
+                BlockCompressedInputStream.FileTermination.HAS_TERMINATOR_BLOCK) {
+            throw new IOException("Terminator block not found after closing BGZF file " + this.file);
+        }
+    }
+
+    /**
+     * Writes the specified byte to this output stream. The general contract for write is that one byte is written
+     * to the output stream. The byte to be written is the eight low-order bits of the argument b.
+     * The 24 high-order bits of b are ignored.
+     * @param bite
+     * @throws IOException
+     */
+    @Override
+    public void write(final int bite) throws IOException {
+        singleByteArray[0] = (byte)bite;
+        write(singleByteArray);
+    }
+
+    /** Encode virtual file pointer
+     * Upper 48 bits is the byte offset into the compressed stream of a block.
+     * Lower 16 bits is the byte offset into the uncompressed stream inside the block.
+     */
+    public long getFilePointer(){
+        return BlockCompressedFilePointerUtil.makeFilePointer(mBlockAddress, numUncompressedBytes);
+    }
+
+    @Override
+    public long getPosition() {
+        return getFilePointer();
+    }
+
+    /**
+     * Attempt to write the data in uncompressedBuffer to the underlying file in a gzip block.
+     * If the entire uncompressedBuffer does not fit in the maximum allowed size, reduce the amount
+     * of data to be compressed, and slide the excess down in uncompressedBuffer so it can be picked
+     * up in the next deflate event.
+     */
+    protected abstract void deflateBlock();
+
+    /**
+     * Writes the entire gzip block, assuming the compressed data is stored in compressedBuffer
+     * @return  size of gzip block that was written.
+     */
+    protected int writeGzipBlock(final byte[] compressedBuffer, final int compressedSize, final int uncompressedSize, final long crc) {
+        // Init gzip header
+        codec.writeByte(BlockCompressedStreamConstants.GZIP_ID1);
+        codec.writeByte(BlockCompressedStreamConstants.GZIP_ID2);
+        codec.writeByte(BlockCompressedStreamConstants.GZIP_CM_DEFLATE);
+        codec.writeByte(BlockCompressedStreamConstants.GZIP_FLG);
+        codec.writeInt(0); // Modification time
+        codec.writeByte(BlockCompressedStreamConstants.GZIP_XFL);
+        codec.writeByte(BlockCompressedStreamConstants.GZIP_OS_UNKNOWN);
+        codec.writeShort(BlockCompressedStreamConstants.GZIP_XLEN);
+        codec.writeByte(BlockCompressedStreamConstants.BGZF_ID1);
+        codec.writeByte(BlockCompressedStreamConstants.BGZF_ID2);
+        codec.writeShort(BlockCompressedStreamConstants.BGZF_LEN);
+        final int totalBlockSize = compressedSize + BlockCompressedStreamConstants.BLOCK_HEADER_LENGTH +
+                BlockCompressedStreamConstants.BLOCK_FOOTER_LENGTH;
+
+        // I don't know why we store block size - 1, but that is what the spec says
+        codec.writeShort((short)(totalBlockSize - 1));
+        codec.writeBytes(compressedBuffer, 0, compressedSize);
+        codec.writeInt((int)crc);
+        codec.writeInt(uncompressedSize);
+        return totalBlockSize;
+    }
+
+    /**
+     * Sets the default {@link DeflaterFactory} that will be used for all instances unless specified otherwise in the constructor.
+     * If this method is not called the default is a factory that will create the JDK {@link Deflater}.
+     * @param deflaterFactory non-null default factory.
+     */
+    public static void setDefaultDeflaterFactory(final DeflaterFactory deflaterFactory) {
+        if (deflaterFactory == null) {
+            throw new IllegalArgumentException("null deflaterFactory");
+        }
+        defaultDeflaterFactory = deflaterFactory;
+    }
+
+    public static DeflaterFactory getDefaultDeflaterFactory() {
+        return defaultDeflaterFactory;
+    }
+
+    /**
+     * Sets the GZip compression level for subsequent BlockCompressedOutputStream object creation
+     * that do not specify the compression level.
+     * @param compressionLevel 1 <= compressionLevel <= 9
+     */
+    public static void setDefaultCompressionLevel(final int compressionLevel) {
+        if (compressionLevel < Deflater.NO_COMPRESSION || compressionLevel > Deflater.BEST_COMPRESSION) {
+            throw new IllegalArgumentException("Invalid compression level: " + compressionLevel);
+        }
+        defaultCompressionLevel = compressionLevel;
+    }
+
+    public static int getDefaultCompressionLevel() {
+        return defaultCompressionLevel;
+    }
+}

--- a/src/main/java/htsjdk/samtools/util/output/async/AsyncBlockCompressedOutputStream.java
+++ b/src/main/java/htsjdk/samtools/util/output/async/AsyncBlockCompressedOutputStream.java
@@ -1,0 +1,317 @@
+package htsjdk.samtools.util.output.async;
+
+import htsjdk.samtools.util.BlockCompressedStreamConstants;
+import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.RuntimeIOException;
+import htsjdk.samtools.util.output.AbstractBlockCompressedOutputStream;
+import htsjdk.samtools.util.zip.DeflaterFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.function.Supplier;
+import java.util.zip.CRC32;
+import java.util.zip.Deflater;
+
+public class AsyncBlockCompressedOutputStream extends AbstractBlockCompressedOutputStream {
+
+    private static final int COMPRESSING_THREADS = countCompressingThread();
+
+    private static final ExecutorService gzipExecutorService = Executors.newFixedThreadPool(COMPRESSING_THREADS, runnable -> {
+        Thread thread = Executors.defaultThreadFactory().newThread(runnable);
+        thread.setDaemon(true);
+        return thread;
+    });
+
+    private static final Void NOTHING = null;
+    private static final int BLOCKS_PACK_SIZE = 16 * COMPRESSING_THREADS;
+
+    private DeflaterFactory deflaterFactory;
+    private final int compressionLevel;
+
+    private List<Future<CompressedBlock>> compressedBlocksInFuture = new ArrayList<>(BLOCKS_PACK_SIZE);
+    private CompletableFuture<Void> writeBlocksTask = CompletableFuture.completedFuture(NOTHING);
+
+    /**
+     * Uses default compression level, which is 5 unless changed by setCompressionLevel
+     * Note: this constructor uses the default {@link DeflaterFactory}, see {@link #getDefaultDeflaterFactory()}.
+     * Use {@link #AsyncBlockCompressedOutputStream(File, int, DeflaterFactory)} to specify a custom factory.
+     */
+    public AsyncBlockCompressedOutputStream(final String filename) {
+        this(filename, defaultCompressionLevel);
+    }
+
+    /**
+     * Uses default compression level, which is 5 unless changed by setCompressionLevel
+     * Note: this constructor uses the default {@link DeflaterFactory}, see {@link #getDefaultDeflaterFactory()}.
+     * Use {@link #AsyncBlockCompressedOutputStream(File, int, DeflaterFactory)} to specify a custom factory.
+     */
+    public AsyncBlockCompressedOutputStream(final File file) {
+        this(file, defaultCompressionLevel);
+    }
+
+    /**
+     * Prepare to compress at the given compression level
+     * Note: this constructor uses the default {@link DeflaterFactory}, see {@link #getDefaultDeflaterFactory()}.
+     *
+     * @param compressionLevel 1 <= compressionLevel <= 9
+     */
+    public AsyncBlockCompressedOutputStream(final String filename, final int compressionLevel) {
+        this(new File(filename), compressionLevel);
+    }
+
+    /**
+     * Prepare to compress at the given compression level
+     *
+     * @param compressionLevel 1 <= compressionLevel <= 9
+     *                         Note: this constructor uses the default {@link DeflaterFactory}, see {@link #getDefaultDeflaterFactory()}.
+     *                         Use {@link #AsyncBlockCompressedOutputStream(File, int, DeflaterFactory)} to specify a custom factory.
+     */
+    public AsyncBlockCompressedOutputStream(final File file, final int compressionLevel) {
+        this(file, compressionLevel, defaultDeflaterFactory);
+    }
+
+    /**
+     * Prepare to compress at the given compression level
+     *
+     * @param compressionLevel 1 <= compressionLevel <= 9
+     * @param deflaterFactory  custom factory to create deflaters (overrides the default)
+     */
+    public AsyncBlockCompressedOutputStream(final File file, final int compressionLevel, final DeflaterFactory deflaterFactory) {
+        this(IOUtil.toPath(file), compressionLevel, deflaterFactory);
+    }
+
+    public AsyncBlockCompressedOutputStream(final OutputStream os, final Path file) {
+        super(os, file);
+        this.compressionLevel = defaultCompressionLevel;
+        this.deflaterFactory = defaultDeflaterFactory;
+    }
+
+    /**
+     * Note: this constructor uses the default {@link DeflaterFactory}, see {@link #getDefaultDeflaterFactory()}.
+     * Use {@link #AsyncBlockCompressedOutputStream(OutputStream, Path, int, DeflaterFactory)} to specify a custom factory.
+     */
+    public AsyncBlockCompressedOutputStream(final OutputStream os, final Path file, final int compressionLevel) {
+        this(os, file, compressionLevel, defaultDeflaterFactory);
+    }
+
+    /**
+     * Prepare to compress at the given compression level
+     *
+     * @param compressionLevel 1 <= compressionLevel <= 9
+     * @param deflaterFactory  custom factory to create deflaters (overrides the default)
+     */
+    public AsyncBlockCompressedOutputStream(final Path path, final int compressionLevel, final DeflaterFactory deflaterFactory) {
+        super(path);
+        this.compressionLevel = compressionLevel;
+        this.deflaterFactory = deflaterFactory;
+    }
+
+    /**
+     * Creates the output stream.
+     *
+     * @param os               output stream to create a BlockCompressedOutputStream from
+     * @param file             file to which to write the output or null if not available
+     * @param compressionLevel the compression level (0-9)
+     * @param deflaterFactory  custom factory to create deflaters (overrides the default)
+     */
+    public AsyncBlockCompressedOutputStream(final OutputStream os, final Path file, final int compressionLevel, final DeflaterFactory deflaterFactory) {
+        super(os, file);
+        this.compressionLevel = compressionLevel;
+        this.deflaterFactory = deflaterFactory;
+    }
+
+    private static int countCompressingThread() {
+        int availableProcessors = Runtime.getRuntime().availableProcessors();
+        return (availableProcessors <= 2) ? 2 : (availableProcessors - 2);
+    }
+
+    /**
+     * WARNING: flush() affects the output format, because it causes the current contents of uncompressedBuffer
+     * to be compressed and written, even if it isn't full.  Unless you know what you're doing, don't call flush().
+     * Instead, call close(), which will flush any unwritten data before closing the underlying stream.
+     */
+    @Override
+    public void flush() throws IOException {
+        while (numUncompressedBytes > 0) {
+            deflateBlock();
+        }
+        processWritingTask();
+        writeBlocksTask.join();
+        codec.getOutputStream().flush();
+    }
+
+    /**
+     * close() must be called in order to flush any remaining buffered bytes. An unclosed file will likely be
+     * defective.
+     */
+    @Override
+    public void close() throws IOException {
+        close(true);
+    }
+
+    /**
+     * @see AbstractBlockCompressedOutputStream#getFilePointer();
+     * This implementation of get file pointer is blocking, because we have to wait to the end
+     * of writing all provided data for getting right pointer.
+     */
+    @Override
+    public long getFilePointer() {
+        processWritingTask();
+        writeBlocksTask.join();
+        return super.getFilePointer();
+    }
+
+    /**
+     * Process new deflate task of the current uncompressed byte buffer.
+     */
+    @Override
+    protected void deflateBlock() {
+        if (numUncompressedBytes == 0) {
+            return;
+        }
+        processDeflateTask();
+        numUncompressedBytes = 0;
+
+        if (BLOCKS_PACK_SIZE == compressedBlocksInFuture.size()) {
+            processWritingTask();
+        }
+    }
+
+    void processDeflateTask() {
+        UncompressedBlock uncompressedBlock =
+                new UncompressedBlock(Arrays.copyOf(this.uncompressedBuffer, numUncompressedBytes), numUncompressedBytes);
+        compressedBlocksInFuture.add(CompletableFuture.supplyAsync(new BlockCompressingTask(uncompressedBlock), gzipExecutorService));
+    }
+
+    void processWritingTask() {
+        writeBlocksTask.join();
+        writeBlocksTask = CompletableFuture.runAsync(new BlockWritingTask(compressedBlocksInFuture), gzipExecutorService);
+        compressedBlocksInFuture = new ArrayList<>(BLOCKS_PACK_SIZE);
+    }
+
+    private class BlockWritingTask implements Runnable {
+
+        private List<Future<CompressedBlock>> compressedBlocks;
+
+        private BlockWritingTask(List<Future<CompressedBlock>> compressedBlocks) {
+            this.compressedBlocks = compressedBlocks;
+        }
+
+        @Override
+        public void run() {
+            for (Future<CompressedBlock> compressedBlockFuture : compressedBlocks) {
+                try {
+                    CompressedBlock compressedBlock = compressedBlockFuture.get();
+                    mBlockAddress += writeGzipBlock(compressedBlock.getCompressedBuffer(), compressedBlock.getCompressedSize(),
+                            compressedBlock.getBytesToCompress(), compressedBlock.getCrc32Value());
+
+                    // Call out to the indexer if it exists
+                    if (indexer != null) {
+                        indexer.addGzipBlock(mBlockAddress, compressedBlock.getBytesToCompress());
+                    }
+                } catch (InterruptedException | ExecutionException e) {
+                    throw new RuntimeIOException("Enable to write Compressed block", e);
+                }
+            }
+        }
+    }
+
+    private class BlockCompressingTask implements Supplier<CompressedBlock> {
+
+        private UncompressedBlock uncompressedBlock;
+
+        private BlockCompressingTask(UncompressedBlock uncompressedBlock) {
+            this.uncompressedBlock = uncompressedBlock;
+        }
+
+        @Override
+        public CompressedBlock get() {
+            return compressBlock(uncompressedBlock);
+        }
+
+        private CompressedBlock compressBlock(UncompressedBlock uncompressedBlock) {
+            final CRC32 crc32 = new CRC32();
+            final Deflater deflater = deflaterFactory.makeDeflater(compressionLevel, true);
+
+            final byte[] compressedBuffer = new byte[BlockCompressedStreamConstants.MAX_COMPRESSED_BLOCK_SIZE -
+                    BlockCompressedStreamConstants.BLOCK_HEADER_LENGTH];
+            // Compress the input
+            deflater.setInput(uncompressedBlock.getUncompressedBuffer(), 0, uncompressedBlock.getBytesToCompress());
+            deflater.finish();
+            int compressedSize = deflater.deflate(compressedBuffer, 0, compressedBuffer.length);
+
+            // If it didn't all fit in uncompressedBuffer.length, set compression level to NO_COMPRESSION
+            // and try again.  This should always fit.
+            if (!deflater.finished()) {
+                final Deflater noCompressionDeflater = deflaterFactory.makeDeflater(Deflater.NO_COMPRESSION, true);
+                noCompressionDeflater.setInput(uncompressedBlock.getUncompressedBuffer(), 0, uncompressedBlock.getBytesToCompress());
+                noCompressionDeflater.finish();
+                compressedSize = noCompressionDeflater.deflate(compressedBuffer, 0, compressedBuffer.length);
+                if (!noCompressionDeflater.finished()) {
+                    throw new IllegalStateException("Impossible");
+                }
+            }
+
+            // Data compressed small enough, so write it out.
+            crc32.update(uncompressedBlock.getUncompressedBuffer(), 0, uncompressedBlock.getBytesToCompress());
+            return new CompressedBlock(compressedBuffer, compressedSize, uncompressedBlock.getBytesToCompress(), crc32.getValue());
+        }
+    }
+
+    private static class CompressedBlock {
+
+        private byte[] compressedBuffer;
+        private int compressedSize;
+        private int bytesToCompress;
+        private long crc32Value;
+
+        private CompressedBlock(byte[] compressedBuffer, int compressedSize, int bytesToCompress, long crc32Value) {
+            this.compressedBuffer = compressedBuffer;
+            this.compressedSize = compressedSize;
+            this.bytesToCompress = bytesToCompress;
+            this.crc32Value = crc32Value;
+        }
+
+        private byte[] getCompressedBuffer() {
+            return compressedBuffer;
+        }
+
+        private int getCompressedSize() {
+            return compressedSize;
+        }
+
+        private int getBytesToCompress() {
+            return bytesToCompress;
+        }
+
+        private long getCrc32Value() {
+            return crc32Value;
+        }
+    }
+
+    private static class UncompressedBlock {
+
+        private byte[] uncompressedBuffer;
+        private int bytesToCompress;
+
+        private UncompressedBlock(byte[] uncompressedBuffer, int bytesToCompress) {
+            this.uncompressedBuffer = uncompressedBuffer;
+            this.bytesToCompress = bytesToCompress;
+        }
+
+        private byte[] getUncompressedBuffer() {
+            return uncompressedBuffer;
+        }
+
+        private int getBytesToCompress() {
+            return bytesToCompress;
+        }
+    }
+
+}

--- a/src/test/java/htsjdk/samtools/BAMFileWriterTest.java
+++ b/src/test/java/htsjdk/samtools/BAMFileWriterTest.java
@@ -229,7 +229,7 @@ public class BAMFileWriterTest extends HtsjdkTest {
         originalSAMRecord.setBaseQualities(SAMRecord.NULL_QUALS);
 
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        try (final BAMFileWriter writer = new BAMFileWriter(baos, null)) {
+        try (final BAMFileWriter writer = new BAMFileWriter(baos, null, false)) {
             writer.setHeader(header);
             writer.addAlignment(originalSAMRecord);
         }
@@ -252,7 +252,7 @@ public class BAMFileWriterTest extends HtsjdkTest {
 
         //encode as BAM into ByteArray
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        try (final BAMFileWriter writer = new BAMFileWriter(baos, null)) {
+        try (final BAMFileWriter writer = new BAMFileWriter(baos, null, false)) {
             writer.setHeader(builder.getHeader());
             builder.getRecords().forEach(writer::addAlignment);
         }
@@ -525,7 +525,7 @@ public class BAMFileWriterTest extends HtsjdkTest {
 
         //encode as BAM into ByteArray
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        try (final BAMFileWriter writer = new BAMFileWriter(baos, null)) {
+        try (final BAMFileWriter writer = new BAMFileWriter(baos, null, false)) {
             writer.setHeader(builder.getHeader());
             builder.forEach(r -> r.setAttribute("xx", "Testing123"));
             builder.forEach(writer::addAlignment);

--- a/src/test/java/htsjdk/samtools/util/AsyncBlockCompressedOutputStreamTest.java
+++ b/src/test/java/htsjdk/samtools/util/AsyncBlockCompressedOutputStreamTest.java
@@ -1,0 +1,199 @@
+package htsjdk.samtools.util;
+
+import htsjdk.HtsjdkTest;
+import htsjdk.samtools.FileTruncatedException;
+import htsjdk.samtools.util.output.async.AsyncBlockCompressedOutputStream;
+import htsjdk.samtools.util.zip.DeflaterFactory;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.zip.Deflater;
+
+public class AsyncBlockCompressedOutputStreamTest extends HtsjdkTest {
+
+    private static final String HTSJDK_TRIBBLE_RESOURCES = "src/test/resources/htsjdk/tribble/";
+
+    @Test
+    public void testBasic() throws Exception {
+        final File f = File.createTempFile("BCOST.", ".gz");
+        f.deleteOnExit();
+        final List<String> linesWritten = new ArrayList<>();
+        System.out.println("Creating file " + f);
+        final AsyncBlockCompressedOutputStream bcos = new AsyncBlockCompressedOutputStream(f);
+        String s = "Hi, Mom!\n";
+        bcos.write(s.getBytes());
+        linesWritten.add(s);
+        s = "Hi, Dad!\n";
+        bcos.write(s.getBytes());
+        linesWritten.add(s);
+        bcos.flush();
+        final StringBuilder sb = new StringBuilder(BlockCompressedStreamConstants.DEFAULT_UNCOMPRESSED_BLOCK_SIZE * 2);
+        s = "1234567890123456789012345678901234567890123456789012345678901234567890\n";
+        while (sb.length() <= BlockCompressedStreamConstants.DEFAULT_UNCOMPRESSED_BLOCK_SIZE) {
+            sb.append(s);
+            linesWritten.add(s);
+        }
+        bcos.write(sb.toString().getBytes());
+        bcos.close();
+        final BlockCompressedInputStream bcis = new BlockCompressedInputStream(f);
+        final BufferedReader reader = new BufferedReader(new InputStreamReader(bcis));
+        String line;
+        for(int i = 0; (line = reader.readLine()) != null; ++i) {
+            Assert.assertEquals(line + "\n", linesWritten.get(i));
+        }
+        bcis.close();
+        final BlockCompressedInputStream bcis2 = new BlockCompressedInputStream(f);
+        int available = bcis2.available();
+        Assert.assertFalse(bcis2.endOfBlock(), "Should not be at end of block");
+        Assert.assertTrue(available > 0);
+        byte[] buffer = new byte[available];
+        Assert.assertEquals(bcis2.read(buffer), available, "Should read to end of block");
+        Assert.assertTrue(bcis2.endOfBlock(), "Should be at end of block");
+        bcis2.close();
+        Assert.assertEquals(bcis2.read(buffer), -1, "Should be end of file");
+    }
+
+    @DataProvider(name = "seekReadExceptionsData")
+    private Object[][] seekReadExceptionsData()
+    {
+        return new Object[][]{
+                {HTSJDK_TRIBBLE_RESOURCES + "vcfexample.vcf.truncated.gz", FileTruncatedException.class,
+                        BlockCompressedInputStream.PREMATURE_END_MSG + System.getProperty("user.dir") + "/" +
+                                HTSJDK_TRIBBLE_RESOURCES + "vcfexample.vcf.truncated.gz", true, false, false, 0},
+                {HTSJDK_TRIBBLE_RESOURCES + "vcfexample.vcf.truncated.hdr.gz", IOException.class,
+                        BlockCompressedInputStream.INCORRECT_HEADER_SIZE_MSG + System.getProperty("user.dir") + "/" +
+                                HTSJDK_TRIBBLE_RESOURCES + "vcfexample.vcf.truncated.hdr.gz", true, false, false, 0},
+                {HTSJDK_TRIBBLE_RESOURCES + "vcfexample.vcf.gz", IOException.class,
+                        BlockCompressedInputStream.CANNOT_SEEK_STREAM_MSG, false, true, false, 0},
+                {HTSJDK_TRIBBLE_RESOURCES + "vcfexample.vcf.gz", IOException.class,
+                        BlockCompressedInputStream.CANNOT_SEEK_CLOSED_STREAM_MSG, false, true, true, 0},
+                {HTSJDK_TRIBBLE_RESOURCES + "vcfexample.vcf.gz", IOException.class,
+                        BlockCompressedInputStream.INVALID_FILE_PTR_MSG + 1000 + " for " + System.getProperty("user.dir") + "/" +
+                                HTSJDK_TRIBBLE_RESOURCES + "vcfexample.vcf.gz", true, true, false, 1000 }
+        };
+    }
+
+    @Test(dataProvider = "seekReadExceptionsData")
+    public void testSeekReadExceptions(final String filePath, final Class c, final String msg, final boolean isFile, final boolean isSeek, final boolean isClosed,
+                                       final int pos) throws Exception {
+
+        final BlockCompressedInputStream bcis = isFile ?
+                new BlockCompressedInputStream(new File(filePath)) :
+                new BlockCompressedInputStream(new FileInputStream(filePath));
+
+        if ( isClosed ) {
+            bcis.close();
+        }
+
+        boolean haveException = false;
+        try {
+            if ( isSeek ) {
+                bcis.seek(pos);
+            } else {
+                final BufferedReader reader = new BufferedReader(new InputStreamReader(bcis));
+                reader.readLine();
+            }
+        } catch (final Exception e) {
+            if ( e.getClass().equals(c) ) {
+                haveException = true;
+                Assert.assertEquals(e.getMessage(), msg);
+            }
+        }
+
+        if ( !haveException ) {
+            Assert.fail("Expected " + c.getSimpleName());
+        }
+    }
+
+    @Test public void testOverflow() throws Exception {
+        final File f = File.createTempFile("BCOST.", ".gz");
+        f.deleteOnExit();
+        System.out.println("Creating file " + f);
+        final AsyncBlockCompressedOutputStream bcos = new AsyncBlockCompressedOutputStream(f);
+        Random r = new Random(15555);
+        final int INPUT_SIZE = 64 * 1024;
+        byte[] input = new byte[INPUT_SIZE];
+        r.nextBytes(input);
+        bcos.write(input);
+        bcos.close();
+
+        final BlockCompressedInputStream bcis = new BlockCompressedInputStream(f);
+        byte[] output = new byte[INPUT_SIZE];
+        int len;
+        int i = 0;
+        while ((len = bcis.read(output, 0, output.length)) != -1) {
+            for (int j = 0; j < len; j++) {
+                Assert.assertEquals(output[j], input[i++]);
+            }
+        }
+        Assert.assertEquals(i, INPUT_SIZE);
+        bcis.close();
+    }
+
+    // PIC-393 exception closing BGZF stream opened to /dev/null
+    // I don't think this will work on Windows, because /dev/null doesn't work
+    @Test(groups = "broken")
+    public void testDevNull() throws Exception {
+        final AsyncBlockCompressedOutputStream bcos = new AsyncBlockCompressedOutputStream("/dev/null");
+        bcos.write("Hi, Mom!".getBytes());
+        bcos.close();
+    }
+
+    @Test
+    public void testCustomDeflater() throws Exception {
+        final File f = File.createTempFile("testCustomDeflater.", ".gz");
+        f.deleteOnExit();
+        System.out.println("Creating file " + f);
+
+        final int[] deflateCalls = {0}; //Note: using and array is a HACK to fool the compiler
+
+        class MyDeflater extends Deflater {
+            MyDeflater(int level, boolean gzipCompatible){
+                super(level, gzipCompatible);
+            }
+            @Override
+            public int deflate(byte[] b, int off, int len) {
+                deflateCalls[0]++;
+                return super.deflate(b, off, len);
+            }
+
+        }
+        final DeflaterFactory myDeflaterFactory= new DeflaterFactory(){
+            @Override
+            public Deflater makeDeflater(final int compressionLevel, final boolean gzipCompatible) {
+                return new MyDeflater(compressionLevel, gzipCompatible);
+            }
+        };
+        final List<String> linesWritten = new ArrayList<>();
+        final AsyncBlockCompressedOutputStream bcos = new AsyncBlockCompressedOutputStream(f, 5, myDeflaterFactory);
+        String s = "Hi, Mom!\n";
+        bcos.write(s.getBytes()); //Call 1
+        linesWritten.add(s);
+        s = "Hi, Dad!\n";
+        bcos.write(s.getBytes()); //Call 2
+        linesWritten.add(s);
+        bcos.flush();
+        final StringBuilder sb = new StringBuilder(BlockCompressedStreamConstants.DEFAULT_UNCOMPRESSED_BLOCK_SIZE * 2);
+        s = "1234567890123456789012345678901234567890123456789012345678901234567890\n";
+        while (sb.length() <= BlockCompressedStreamConstants.DEFAULT_UNCOMPRESSED_BLOCK_SIZE) {
+            sb.append(s);
+            linesWritten.add(s);
+        }
+        bcos.write(sb.toString().getBytes()); //Call 3
+        bcos.close();
+        final BlockCompressedInputStream bcis = new BlockCompressedInputStream(f);
+        final BufferedReader reader = new BufferedReader(new InputStreamReader(bcis));
+        String line;
+        for(int i = 0; (line = reader.readLine()) != null; ++i) {
+            Assert.assertEquals(line + "\n", linesWritten.get(i));
+        }
+        bcis.close();
+        Assert.assertEquals(deflateCalls[0], 3, "deflate calls");
+        Assert.assertNull(reader.readLine());
+    }
+}


### PR DESCRIPTION
AsyncBlockCompressedOutputStream implementation.

Here are also performance result SortSam where BlockCompressedOutputStream is used:
### Inputfile: 96,1mb (x2 profit)
#### master:
```
Benchmark                            (bufferSize)  Mode  Cnt      Score   Error  Units
SamBenchMark.sortingBufferParameter         50000    ss       12140.642          ms/op
SamBenchMark.sortingBufferParameter        100000    ss       11656.378          ms/op
SamBenchMark.sortingBufferParameter        400000    ss       12310.376          ms/op
SamBenchMark.sortingBufferParameter        500000    ss       12052.047          ms/op
SamBenchMark.sortingBufferParameter       1000000    ss       12575.294          ms/op
SamBenchMark.sortingBufferParameter       1500000    ss       12129.808          ms/op
SamBenchMark.sortingBufferParameter       2000000    ss       10250.480          ms/op
SamBenchMark.sortingBufferParameter       2500000    ss       10288.553          ms/op
```

#### AsyncBlockCompressedOutputStream:
```
Benchmark                            (bufferSize)  Mode  Cnt     Score   Error  Units
SamBenchMark.sortingBufferParameter         50000    ss       5357.160          ms/op
SamBenchMark.sortingBufferParameter        100000    ss       5404.317          ms/op
SamBenchMark.sortingBufferParameter        400000    ss       5799.517          ms/op
SamBenchMark.sortingBufferParameter        500000    ss       6091.215          ms/op
SamBenchMark.sortingBufferParameter       1000000    ss       6195.157          ms/op
SamBenchMark.sortingBufferParameter       1500000    ss       6579.340          ms/op
SamBenchMark.sortingBufferParameter       2000000    ss       4888.262          ms/op
SamBenchMark.sortingBufferParameter       2500000    ss       4876.111          ms/op
```

### Inputfile: 947,9mb (~x2 profit)
#### master:
```
Benchmark                            (bufferSize)  Mode  Cnt       Score   Error  Units
SamBenchMark.sortingBufferParameter         50000    ss       113631.729          ms/op
SamBenchMark.sortingBufferParameter        100000    ss       113185.477          ms/op
SamBenchMark.sortingBufferParameter        400000    ss       122839.217          ms/op
SamBenchMark.sortingBufferParameter        500000    ss       114307.357          ms/op
SamBenchMark.sortingBufferParameter       1000000    ss       116134.463          ms/op
SamBenchMark.sortingBufferParameter       1500000    ss       117954.202          ms/op
SamBenchMark.sortingBufferParameter       2000000    ss       117627.674          ms/op
SamBenchMark.sortingBufferParameter       2500000    ss       118221.354          ms/op
```

#### AsyncBlockCompressedOutputStream:
```
Benchmark                            (bufferSize)  Mode  Cnt      Score   Error  Units
SamBenchMark.sortingBufferParameter         50000    ss       56606.235          ms/op
SamBenchMark.sortingBufferParameter        100000    ss       53325.817          ms/op
SamBenchMark.sortingBufferParameter        400000    ss       59600.956          ms/op
SamBenchMark.sortingBufferParameter        500000    ss       54590.446          ms/op
SamBenchMark.sortingBufferParameter       1000000    ss       56417.313          ms/op
SamBenchMark.sortingBufferParameter       1500000    ss       56408.919          ms/op
SamBenchMark.sortingBufferParameter       2000000    ss       57517.868          ms/op
SamBenchMark.sortingBufferParameter       2500000    ss       57288.133          ms/op
```

Tests:
```
Total number of tests run: 29380
Suites: completed 305, aborted 0
Tests: succeeded 29380, failed 0, canceled 0, ignored 0, pending 0
```